### PR TITLE
Update index.js

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -227,7 +227,7 @@ RedisCluster.prototype.sendClusterCommand = function (command, args, callback) {
                 var parts = err.toString().split(" ");
                 if (parts[1] === "MOVED") {
                     // update the cluster, and redo the call
-                    var new_location = parts[3].slice(':');
+                    var new_location = parts[3].split(':');
                     self.slots[parts[2]*1] = {host: new_location[0], port: new_location[1]*1};
 
                     // calls itself, re-adding the callback as the last element of the args array


### PR DESCRIPTION
I tested this fix and found out a little bug. I believe the split function was expected to be used instead of slice line 230.

And I confirmed I needed this fix for the redis-party to work correctly at getting redirected correctly depending on the key slot.
